### PR TITLE
Replace educational content with focused Manianaa app promotion

### DIFF
--- a/src/calculatorManiany/components/EducationalContent.tsx
+++ b/src/calculatorManiany/components/EducationalContent.tsx
@@ -1,156 +1,53 @@
 import React from 'react'
 import { Box, Typography, Button } from '@mui/material'
 
-const faqItems = [
-  {
-    question: 'Czy kalkulator kalorii jest dokładny?',
-    answer:
-      'Kalkulator daje przybliżoną wartość opartą na wzorze Mifflin-St Jeor. To dobry punkt wyjścia, ale każdy organizm jest inny. Obserwuj swoją wagę i samopoczucie i dostosowuj kaloryczność w miarę potrzeby.',
-  },
-  {
-    question: 'Jak często przeliczać zapotrzebowanie kaloryczne?',
-    answer:
-      'Warto przeliczać co 4–6 tygodni lub po każdej istotnej zmianie wagi (więcej niż 2–3 kg), aktywności fizycznej lub stylu życia.',
-  },
-  {
-    question: 'Czy mogę jeść mniej niż pokazuje kalkulator?',
-    answer:
-      'Jedzenie znacznie poniżej swojego zapotrzebowania może prowadzić do niedoborów, utraty masy mięśniowej i spowolnienia metabolizmu. Zamiast drastycznych obniżek, lepiej zastosować umiarkowany deficyt i obserwować efekty.',
-  },
-  {
-    question: 'Co zrobić, jeśli waga nie spada?',
-    answer:
-      'Sprawdź, czy dokładnie liczysz kalorie i czy nie niedoszacowujesz porcji. Upewnij się, że śpisz wystarczająco i nie jesteś w okresie stresu. Jeśli stagnacja trwa dłużej niż 2–3 tygodnie, rozważ niewielkie obniżenie kalorii lub zwiększenie aktywności.',
-  },
-]
-
 const EducationalContent: React.FC = () => {
   return (
     <Box
-      component="article"
+      component="section"
       sx={{
-        maxWidth: '720px',
+        maxWidth: '560px',
         margin: '0 auto',
         padding: { xs: '32px 20px', sm: '48px 24px' },
       }}
     >
-      <Box component="section" sx={{ mb: 5 }}>
-        <Typography
-          variant="h2"
-          sx={{
-            fontFamily: '"Libre Bodoni", serif',
-            fontSize: { xs: '22px', sm: '26px' },
-            fontWeight: 600,
-            color: '#1a1a1a',
-            mb: 2,
-          }}
-        >
-          Jak działa kalkulator zapotrzebowania kalorycznego?
-        </Typography>
-        <Typography sx={{ color: '#444', lineHeight: 1.7, fontSize: '15px' }}>
-          Kalkulator wykorzystuje wzór Mifflin-St Jeor, który na podstawie Twojej płci, wagi,
-          wzrostu, wieku i poziomu aktywności fizycznej szacuje dzienne zapotrzebowanie kaloryczne.
-          Następnie dostosowuje wynik do Twojego celu — redukcji, utrzymania lub budowania masy
-          ciała. To jeden z najdokładniejszych wzorów stosowanych w dietetyce.
-        </Typography>
-      </Box>
-
-      <Box component="section" sx={{ mb: 5 }}>
-        <Typography
-          variant="h2"
-          sx={{
-            fontFamily: '"Libre Bodoni", serif',
-            fontSize: { xs: '22px', sm: '26px' },
-            fontWeight: 600,
-            color: '#1a1a1a',
-            mb: 2,
-          }}
-        >
-          Co oznacza zero kaloryczne?
-        </Typography>
-        <Typography sx={{ color: '#444', lineHeight: 1.7, fontSize: '15px' }}>
-          &bdquo;Zero kaloryczne&rdquo; (czyli kalorie na utrzymanie) to przybliżona ilość energii,
-          przy której Twoja waga pozostaje stabilna. Nie przybierasz ani nie tracisz. To Twój punkt
-          odniesienia — zarówno gdy chcesz schudnąć (jedzenie poniżej zera), jak i gdy chcesz
-          przybrać (jedzenie powyżej zera).
-        </Typography>
-      </Box>
-
-      <Box component="section" sx={{ mb: 5 }}>
-        <Typography
-          variant="h2"
-          sx={{
-            fontFamily: '"Libre Bodoni", serif',
-            fontSize: { xs: '22px', sm: '26px' },
-            fontWeight: 600,
-            color: '#1a1a1a',
-            mb: 2,
-          }}
-        >
-          Ile kalorii jeść na redukcji?
-        </Typography>
-        <Typography sx={{ color: '#444', lineHeight: 1.7, fontSize: '15px' }}>
-          Redukcja zazwyczaj zaczyna się od umiarkowanego deficytu kalorycznego — około 200–400 kcal
-          poniżej zapotrzebowania na utrzymanie. Zbyt drastyczne obniżenie kalorii może prowadzić
-          do utraty mięśni, zmęczenia i efektu jo-jo. Kluczowe jest monitorowanie postępów i
-          samopoczucia, a kaloryczność dostosowuj stopniowo.
-        </Typography>
-      </Box>
-
-      <Box component="section" sx={{ mb: 5 }}>
-        <Typography
-          variant="h2"
-          sx={{
-            fontFamily: '"Libre Bodoni", serif',
-            fontSize: { xs: '22px', sm: '26px' },
-            fontWeight: 600,
-            color: '#1a1a1a',
-            mb: 2,
-          }}
-        >
-          Ile kalorii jeść, żeby utrzymać masę ciała?
-        </Typography>
-        <Typography sx={{ color: '#444', lineHeight: 1.7, fontSize: '15px' }}>
-          Utrzymanie to jedzenie na poziomie Twojego zapotrzebowania kalorycznego. To świetna
-          strategia po okresie redukcji (aby ustabilizować metabolizm) lub przed rozpoczęciem nowego
-          celu. Daje organizmowi czas na regenerację i pozwala lepiej poznać swoje potrzeby
-          energetyczne.
-        </Typography>
-      </Box>
-
-      <Box component="section" sx={{ mb: 5 }}>
-        <Typography
-          variant="h2"
-          sx={{
-            fontFamily: '"Libre Bodoni", serif',
-            fontSize: { xs: '22px', sm: '26px' },
-            fontWeight: 600,
-            color: '#1a1a1a',
-            mb: 2,
-          }}
-        >
-          Ile kalorii jeść na masie?
-        </Typography>
-        <Typography sx={{ color: '#444', lineHeight: 1.7, fontSize: '15px' }}>
-          Budowanie masy wymaga stopniowej nadwyżki kalorycznej — zazwyczaj około 200–400 kcal
-          powyżej utrzymania. Ważne jest, aby nadwyżka nie była zbyt duża (żeby minimalizować
-          przyrost tkanki tłuszczowej) i towarzyszyły jej regularne treningi siłowe. Monitoruj wagę
-          i skład ciała co tydzień.
-        </Typography>
-      </Box>
-
       <Box
         sx={{
           textAlign: 'center',
-          py: 3,
-          px: 2,
+          py: { xs: 4, sm: 5 },
+          px: { xs: 3, sm: 4 },
           backgroundColor: '#fff5f8',
-          borderRadius: '16px',
-          mb: 5,
+          borderRadius: '24px',
+          boxShadow: '0 4px 20px rgba(234, 64, 112, 0.08)',
         }}
       >
-        <Typography sx={{ color: '#555', fontSize: '15px', mb: 2 }}>
-          Nie wiesz, co dalej? Sprawdź dietę w aplikacji Manianaa.
+        <Typography
+          variant="h2"
+          sx={{
+            fontFamily: '"Libre Bodoni", serif',
+            fontSize: { xs: '22px', sm: '26px' },
+            fontWeight: 600,
+            color: '#1a1a1a',
+            mb: 2,
+          }}
+        >
+          Nie wiesz, co dalej?
+        </Typography>
+        <Typography
+          sx={{ color: '#555', fontSize: '15px', lineHeight: 1.7, mb: 1 }}
+        >
+          Masz już swoje zapotrzebowanie kaloryczne — teraz pora na plan działania.
+        </Typography>
+        <Typography
+          sx={{ color: '#555', fontSize: '15px', lineHeight: 1.7, mb: 1 }}
+        >
+          W aplikacji Maniany znajdziesz gotowe jadłospisy dopasowane do Twojej kaloryczności,
+          listę zakupów i proste przepisy na każdy dzień. Bez liczenia, bez zgadywania.
+        </Typography>
+        <Typography
+          sx={{ color: '#555', fontSize: '15px', lineHeight: 1.7, mb: 3 }}
+        >
+          Dołącz do tysięcy kobiet, które już jedzą smacznie i zgodnie ze swoim celem.
         </Typography>
         <Button
           component="a"
@@ -161,74 +58,19 @@ const EducationalContent: React.FC = () => {
           sx={{
             backgroundColor: '#ea4070',
             color: '#fff',
-            fontWeight: 600,
-            borderRadius: '10px',
+            fontWeight: 700,
+            fontSize: '16px',
+            borderRadius: '12px',
             textTransform: 'none',
-            padding: '12px 28px',
+            padding: '14px 36px',
             '&:hover': { backgroundColor: '#d03060' },
+            '&:focus-visible': {
+              outline: '3px solid #ea4070',
+              outlineOffset: '2px',
+            },
           }}
         >
-          Zobacz aplikację Manianaa
-        </Button>
-      </Box>
-
-      <Box component="section" sx={{ mb: 5 }}>
-        <Typography
-          variant="h2"
-          sx={{
-            fontFamily: '"Libre Bodoni", serif',
-            fontSize: { xs: '22px', sm: '26px' },
-            fontWeight: 600,
-            color: '#1a1a1a',
-            mb: 3,
-          }}
-        >
-          Najczęstsze pytania
-        </Typography>
-        {faqItems.map((item, index) => (
-          <Box key={index} sx={{ mb: 3 }}>
-            <Typography
-              variant="h3"
-              sx={{ fontSize: '16px', fontWeight: 600, color: '#1a1a1a', mb: 0.5 }}
-            >
-              {item.question}
-            </Typography>
-            <Typography sx={{ color: '#555', lineHeight: 1.7, fontSize: '14px' }}>
-              {item.answer}
-            </Typography>
-          </Box>
-        ))}
-      </Box>
-
-      <Box
-        sx={{
-          textAlign: 'center',
-          py: 3,
-          px: 2,
-          backgroundColor: '#f8f5ff',
-          borderRadius: '16px',
-        }}
-      >
-        <Typography sx={{ color: '#555', fontSize: '15px', mb: 2 }}>
-          Chcesz zacząć prościej? Zobacz e-booki Manianaa.
-        </Typography>
-        <Button
-          component="a"
-          href="https://manianaa.com/sklep/"
-          target="_blank"
-          rel="noopener noreferrer"
-          variant="outlined"
-          sx={{
-            color: '#ea4070',
-            borderColor: '#ea4070',
-            fontWeight: 600,
-            borderRadius: '10px',
-            textTransform: 'none',
-            padding: '12px 28px',
-            '&:hover': { backgroundColor: '#fff5f8', borderColor: '#d03060' },
-          }}
-        >
-          Zobacz e-booki
+          Sprawdź dietę w aplikacji Manianaa
         </Button>
       </Box>
     </Box>
@@ -236,16 +78,3 @@ const EducationalContent: React.FC = () => {
 }
 
 export default EducationalContent
-
-export const faqJsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'FAQPage',
-  mainEntity: faqItems.map((item) => ({
-    '@type': 'Question',
-    name: item.question,
-    acceptedAnswer: {
-      '@type': 'Answer',
-      text: item.answer,
-    },
-  })),
-}

--- a/src/calculatorManiany/container/CalculatorContainer.tsx
+++ b/src/calculatorManiany/container/CalculatorContainer.tsx
@@ -1,19 +1,10 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Box, Typography, Container } from '@mui/material'
 import CalculatorManiany from '../components/CalculatorManiany'
-import EducationalContent, { faqJsonLd } from '../components/EducationalContent'
+import EducationalContent from '../components/EducationalContent'
 import '../styles/styles.css'
 
 const CalculatorContainer: React.FC = () => {
-  useEffect(() => {
-    const script = document.createElement('script')
-    script.type = 'application/ld+json'
-    script.textContent = JSON.stringify(faqJsonLd)
-    document.head.appendChild(script)
-    return () => {
-      document.head.removeChild(script)
-    }
-  }, [])
 
   return (
     <Box


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces all educational SEO content sections and FAQ below the calculator with a single, focused promotional section encouraging users to purchase the Manianaa app diet.

### Changes

- **Removed**: All educational H2 sections (how the calculator works, zero caloric explanation, calories for reduction/maintenance/mass)
- **Removed**: FAQ section with JSON-LD schema
- **Removed**: E-books CTA section
- **Kept & enhanced**: "Nie wiesz, co dalej?" promotional section with:
  - Encouraging copy about ready meal plans, shopping lists, and simple daily recipes
  - Social proof: "Dołącz do tysięcy kobiet, które już jedzą smacznie i zgodnie ze swoim celem."
  - CTA button linking to https://manianaa.com/produkt/dieta-maniany-w-aplikacji

### Demo

[demo_simplified_content.mp4](https://cursor.com/agents/bc-36a091ef-5c09-4722-a520-c8cd781a9a03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_simplified_content.mp4)

[Promotional section - Nie wiesz co dalej?](https://cursor.com/agents/bc-36a091ef-5c09-4722-a520-c8cd781a9a03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpromo_section.webp)
[Result card with promo section below](https://cursor.com/agents/bc-36a091ef-5c09-4722-a520-c8cd781a9a03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fresult_with_promo.webp)

### Testing

- ✅ `npx eslint src/ --ext .ts,.tsx` — 0 errors
- ✅ `npm run build` — compiles successfully  
- ✅ `CI=true npm test -- --watchAll=false` — 6/6 passing

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36a091ef-5c09-4722-a520-c8cd781a9a03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36a091ef-5c09-4722-a520-c8cd781a9a03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

